### PR TITLE
Feature/generic timestamp

### DIFF
--- a/resources/lang/en/translations.php
+++ b/resources/lang/en/translations.php
@@ -4,5 +4,6 @@ return [
     'time' => [
         'created_at' => 'Created at',
         'updated_at' => 'Updated at',
+        'deleted_at' => 'Deleted at',
     ]
 ];

--- a/src/Forms/CreatedAt.php
+++ b/src/Forms/CreatedAt.php
@@ -6,8 +6,8 @@ use Filament\Forms\Components\Placeholder;
 
 class CreatedAt
 {
-    public static function make(): Placeholder
+    public static function make(string $label = null): Placeholder
     {
-        return Timestamp::make('created_at');
+        return Timestamp::make('created_at', $label);
     }
 }

--- a/src/Forms/DeletedAt.php
+++ b/src/Forms/DeletedAt.php
@@ -6,8 +6,8 @@ use Filament\Forms\Components\Placeholder;
 
 class DeletedAt
 {
-    public static function make(): Placeholder
+    public static function make(string $label = null): Placeholder
     {
-        return Timestamp::make('deleted_at');
+        return Timestamp::make('deleted_at', $label);
     }
 }

--- a/src/Forms/DeletedAt.php
+++ b/src/Forms/DeletedAt.php
@@ -4,10 +4,10 @@ namespace RalphJSmit\Filament\Components\Forms;
 
 use Filament\Forms\Components\Placeholder;
 
-class CreatedAt
+class DeletedAt
 {
     public static function make(): Placeholder
     {
-        return Timestamp::make('created_at');
+        return Timestamp::make('deleted_at');
     }
 }

--- a/src/Forms/Timestamp.php
+++ b/src/Forms/Timestamp.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace RalphJSmit\Filament\Components\Forms;
+
+use Filament\Forms\Components\Placeholder;
+
+class Timestamp
+{
+    public static function make(string $column, string $label = null): Placeholder
+    {
+        return Placeholder::make($column)
+            ->label($label ?? tr("time.$column"))
+            ->content(fn ($record): string => $record?->$column ? $record->$column->diffForHumans() : '-');
+    }
+}

--- a/src/Forms/Timestamp.php
+++ b/src/Forms/Timestamp.php
@@ -9,7 +9,18 @@ class Timestamp
     public static function make(string $column, string $label = null): Placeholder
     {
         return Placeholder::make($column)
-            ->label($label ?? tr("time.$column"))
+            ->label(function () use ($column, $label) {
+                if ($label) {
+                    return $label;
+                }
+
+                return match ( $column ) {
+                    'created_at' => tr('time.created_at'),
+                    'updated_at' => tr('time.updated_at'),
+                    'deleted_at' => tr('time.deleted_at'),
+                    default => null,
+                };
+            })
             ->content(fn ($record): string => $record?->$column ? $record->$column->diffForHumans() : '-');
     }
 }

--- a/src/Forms/UpdatedAt.php
+++ b/src/Forms/UpdatedAt.php
@@ -6,8 +6,8 @@ use Filament\Forms\Components\Placeholder;
 
 class UpdatedAt
 {
-    public static function make(): Placeholder
+    public static function make(string $label = null): Placeholder
     {
-        return Timestamp::make('updated_at');
+        return Timestamp::make('updated_at', $label);
     }
 }

--- a/src/Forms/UpdatedAt.php
+++ b/src/Forms/UpdatedAt.php
@@ -8,8 +8,6 @@ class UpdatedAt
 {
     public static function make(): Placeholder
     {
-        return Placeholder::make('updated_at')
-            ->label(tr('time.updated_at'))
-            ->content(fn ($record): string => $record?->updated_at ? $record->updated_at->diffForHumans() : '-');
+        return Timestamp::make('updated_at');
     }
 }


### PR DESCRIPTION
Added a generic `Timestamp` field, that accepts a column name and an optional label to display, so it can be used to display custom timestamps.

Refactored the CreatedAt and UpdatedAt fields to use this field and added a new DeletedAt field for soft-deleted models.