### PR TITLE
Update Sidebar's Form import path for compatibility with Filament 3

### DIFF
--- a/src/Forms/Sidebar.php
+++ b/src/Forms/Sidebar.php
@@ -8,10 +8,10 @@ use Filament\Resources\Form;
 class Sidebar
 {
     public function __construct(
-        public Form $form,
+        public Form|\Filament\Forms\Form $form,
     ) {}
 
-    public static function make(Form $form = null): static
+    public static function make(Form|\Filament\Forms\Form|null $form = null): static
     {
         if ( ! $form ) {
             $form = Form::make();
@@ -20,7 +20,7 @@ class Sidebar
         return new static(form: $form);
     }
 
-    public function schema(array $mainComponents, array $sidebarComponents): Form
+    public function schema(array $mainComponents, array $sidebarComponents): Form|\Filament\Forms\Form
     {
         return $this->form->schema([
             Grid::make(['sm' => 3])->schema([

--- a/src/Forms/Sidebar.php
+++ b/src/Forms/Sidebar.php
@@ -14,7 +14,10 @@ class Sidebar
     public static function make(Form|\Filament\Forms\Form|null $form = null): static
     {
         if ( ! $form ) {
-            $form = Form::make();
+            $form = match ( true ) {
+                class_exists(Form::class) => Form::make(),
+                default => \Filament\Forms\Form::make(),
+            };
         }
 
         return new static(form: $form);

--- a/src/Forms/Sidebar.php
+++ b/src/Forms/Sidebar.php
@@ -3,27 +3,28 @@
 namespace RalphJSmit\Filament\Components\Forms;
 
 use Filament\Forms\Components\Grid;
-use Filament\Resources\Form;
+use Filament\Forms\Form;
+use Filament\Resources\Form as FormV2;
 
 class Sidebar
 {
     public function __construct(
-        public Form|\Filament\Forms\Form $form,
+        public FormV2|Form $form,
     ) {}
 
-    public static function make(Form|\Filament\Forms\Form|null $form = null): static
+    public static function make(FormV2|Form|null $form = null): static
     {
         if ( ! $form ) {
             $form = match ( true ) {
-                class_exists(Form::class) => Form::make(),
-                default => \Filament\Forms\Form::make(),
+                class_exists(FormV2::class) => FormV2::make(),
+                default => Form::make(),
             };
         }
 
         return new static(form: $form);
     }
 
-    public function schema(array $mainComponents, array $sidebarComponents): Form|\Filament\Forms\Form
+    public function schema(array $mainComponents, array $sidebarComponents): FormV2|Form
     {
         return $this->form->schema([
             Grid::make(['sm' => 3])->schema([


### PR DESCRIPTION
Extended parameter and return types for Compatibility with Filament 3 which now uses \Filament\Forms\Form instead of \Filament\Resources\Form
- Closes #19 